### PR TITLE
fix: Cannot link douyin,tieba in tophub

### DIFF
--- a/lib/v2/tophub/index.js
+++ b/lib/v2/tophub/index.js
@@ -23,6 +23,11 @@ module.exports = async (ctx) => {
                 title: $(e).find('td.al a').text(),
                 link: $(e).find('td.al a').attr('href'),
             };
+            if (id === "K7GdaMgdQy") { // 抖音
+                info.link = 'https://www.douyin.com/search/' + encodeURIComponent(title);
+            } else if (id === "Om4ejxvxEN") { // 贴吧
+                info.link = 'https://tieba.baidu.com/hottopic/browse/hottopic?topic_name=' + encodeURIComponent(title);
+            }
             return info;
         });
 


### PR DESCRIPTION
由于上游 DIYgod/RSSHub#13104 与 b2f0aaccfe1473bab4ee49d5575ce5ddbc6a3a74 的修改导致丢失之前对tophub的修改，现在添加的对抖音贴吧 tophub跳转链接改为对应的网站搜索链接