### PR TITLE
feat: Rebase mine

### DIFF
--- a/.github/workflows/sync-fork.yml
+++ b/.github/workflows/sync-fork.yml
@@ -2,7 +2,8 @@ name: Sync Upstream to mine
 
 on:
   schedule:
-    - cron: '0 4 * * *'
+    # utc timezone to local shanghai at 04:00
+    - cron: '0 20 * * *'
   workflow_dispatch: ~ # on button click
 
 jobs:
@@ -23,7 +24,7 @@ jobs:
           git fetch upstream
       - name: Merge upstream/master changes
         run: |
-          git merge --ff upstream/master
+          git rebase upstream/master
       - name: Push changes
         uses: ad-m/github-push-action@master
         with:


### PR DESCRIPTION
在 sync-fork.yml 中使用git merge产生了大量的 merge branch 冗余提交，参考[3.6 Git 分支 - 变基](https://git-scm.com/book/zh/v2/Git-%E5%88%86%E6%94%AF-%E5%8F%98%E5%9F%BA)使用`git rebase upstream/master`来移除所有的冗余提交

这个PR将

* 使用git rebase来合并上游分支
* 修复sync-fork 计划任务时间为utc 20:00运行即shanghai 04:00